### PR TITLE
Spells/Warrior: Fix Overpower aura consumption

### DIFF
--- a/sql/updates/world/master/2025_11_27_00_world.sql
+++ b/sql/updates/world/master/2025_11_27_00_world.sql
@@ -1,4 +1,3 @@
 DELETE FROM `spell_proc` WHERE `SpellId` IN (7384);
-INSERT INTO `spell_proc`
-(`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(7384,0x00,4,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x4,0x1,0x0,0x0008,0x0,0,100,0,1); -- Overpower
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(7384,0x00,4,0x00000000,0x00000000,0x00000000,0x00000000,0x0,0x0,0x0,0x2,0x0,0x8,0x0,0,0,0,1); -- Overpower

--- a/sql/updates/world/master/2025_11_27_00_world.sql
+++ b/sql/updates/world/master/2025_11_27_00_world.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spell_proc` WHERE `SpellId` IN (7384);
+INSERT INTO `spell_proc`
+(`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(7384,0x00,4,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x4,0x1,0x0,0x0008,0x0,0,100,0,0); -- Overpower

--- a/sql/updates/world/master/2025_11_27_00_world.sql
+++ b/sql/updates/world/master/2025_11_27_00_world.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell_proc` WHERE `SpellId` IN (7384);
 INSERT INTO `spell_proc`
 (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(7384,0x00,4,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x4,0x1,0x0,0x0008,0x0,0,100,0,0); -- Overpower
+(7384,0x00,4,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x4,0x1,0x0,0x0008,0x0,0,100,0,1); -- Overpower


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Related spells now consume Overpower aura stacks
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**
Builds and consumes like it should


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
